### PR TITLE
Upgrade to v25.02.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ BookStack is an opinionated wiki system that provides a pleasant and simple out 
 - Diagrams.net Integration
 
 
-**Shipped version:** 24.12.1~ynh2
+**Shipped version:** 25.02~ynh1
 
 **Demo:** <https://demo.bookstackapp.com>
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ BookStack is an opinionated wiki system that provides a pleasant and simple out 
 - Diagrams.net Integration
 
 
-**Shipped version:** 24.12~ynh1
+**Shipped version:** 24.12.1~ynh1
 
 **Demo:** <https://demo.bookstackapp.com>
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ BookStack is an opinionated wiki system that provides a pleasant and simple out 
 - Diagrams.net Integration
 
 
-*Shipped version:** 25.02.1~ynh1
+**Shipped version:** 25.02.1~ynh1
 
 **Demo:** <https://demo.bookstackapp.com>
 

--- a/README_es.md
+++ b/README_es.md
@@ -31,7 +31,7 @@ BookStack is an opinionated wiki system that provides a pleasant and simple out 
 - Diagrams.net Integration
 
 
-**Versión actual:** 24.12.1~ynh2
+**Versión actual:** 25.02~ynh1
 
 **Demo:** <https://demo.bookstackapp.com>
 

--- a/README_es.md
+++ b/README_es.md
@@ -31,7 +31,7 @@ BookStack is an opinionated wiki system that provides a pleasant and simple out 
 - Diagrams.net Integration
 
 
-**Versión actual:** 24.12~ynh1
+**Versión actual:** 24.12.1~ynh1
 
 **Demo:** <https://demo.bookstackapp.com>
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -31,7 +31,7 @@ BookStack is an opinionated wiki system that provides a pleasant and simple out 
 - Diagrams.net Integration
 
 
-**Paketatutako bertsioa:** 24.12~ynh1
+**Paketatutako bertsioa:** 24.12.1~ynh1
 
 **Demoa:** <https://demo.bookstackapp.com>
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -31,7 +31,7 @@ BookStack is an opinionated wiki system that provides a pleasant and simple out 
 - Diagrams.net Integration
 
 
-**Paketatutako bertsioa:** 24.12.1~ynh2
+**Paketatutako bertsioa:** 25.02~ynh1
 
 **Demoa:** <https://demo.bookstackapp.com>
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -30,7 +30,7 @@ BookStack est un système wiki simple prête à l'emploi. Les nouveaux utilisate
 - Multilingue
 - Integration avec Diagrams.net 
 
-**Version incluse :** 24.12.1~ynh2
+**Version incluse :** 25.02~ynh1
 
 **Démo :** <https://demo.bookstackapp.com>
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -29,7 +29,7 @@ BookStack est un système wiki simple prête à l'emploi. Les nouveaux utilisate
 - Multilingue
 
 
-**Version incluse :** 24.12~ynh1
+**Version incluse :** 24.12.1~ynh1
 
 **Démo :** <https://demo.bookstackapp.com>
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -31,7 +31,7 @@ BookStack is an opinionated wiki system that provides a pleasant and simple out 
 - Diagrams.net Integration
 
 
-**Versión proporcionada:** 24.12~ynh1
+**Versión proporcionada:** 24.12.1~ynh1
 
 **Demo:** <https://demo.bookstackapp.com>
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -31,7 +31,7 @@ BookStack is an opinionated wiki system that provides a pleasant and simple out 
 - Diagrams.net Integration
 
 
-**Versión proporcionada:** 24.12.1~ynh2
+**Versión proporcionada:** 25.02~ynh1
 
 **Demo:** <https://demo.bookstackapp.com>
 

--- a/README_id.md
+++ b/README_id.md
@@ -31,7 +31,7 @@ BookStack is an opinionated wiki system that provides a pleasant and simple out 
 - Diagrams.net Integration
 
 
-**Versi terkirim:** 24.12~ynh1
+**Versi terkirim:** 24.12.1~ynh1
 
 **Demo:** <https://demo.bookstackapp.com>
 

--- a/README_id.md
+++ b/README_id.md
@@ -31,7 +31,7 @@ BookStack is an opinionated wiki system that provides a pleasant and simple out 
 - Diagrams.net Integration
 
 
-**Versi terkirim:** 24.12.1~ynh2
+**Versi terkirim:** 25.02~ynh1
 
 **Demo:** <https://demo.bookstackapp.com>
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -31,7 +31,7 @@ BookStack is an opinionated wiki system that provides a pleasant and simple out 
 - Diagrams.net Integration
 
 
-**Geleverde versie:** 24.12.1~ynh2
+**Geleverde versie:** 25.02~ynh1
 
 **Demo:** <https://demo.bookstackapp.com>
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -31,7 +31,7 @@ BookStack is an opinionated wiki system that provides a pleasant and simple out 
 - Diagrams.net Integration
 
 
-**Geleverde versie:** 24.12~ynh1
+**Geleverde versie:** 24.12.1~ynh1
 
 **Demo:** <https://demo.bookstackapp.com>
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -31,7 +31,7 @@ BookStack is an opinionated wiki system that provides a pleasant and simple out 
 - Diagrams.net Integration
 
 
-**Dostarczona wersja:** 24.12.1~ynh2
+**Dostarczona wersja:** 25.02~ynh1
 
 **Demo:** <https://demo.bookstackapp.com>
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -31,7 +31,7 @@ BookStack is an opinionated wiki system that provides a pleasant and simple out 
 - Diagrams.net Integration
 
 
-**Dostarczona wersja:** 24.12~ynh1
+**Dostarczona wersja:** 24.12.1~ynh1
 
 **Demo:** <https://demo.bookstackapp.com>
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -31,7 +31,7 @@ BookStack is an opinionated wiki system that provides a pleasant and simple out 
 - Diagrams.net Integration
 
 
-**Поставляемая версия:** 24.12.1~ynh2
+**Поставляемая версия:** 25.02~ynh1
 
 **Демо-версия:** <https://demo.bookstackapp.com>
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -31,7 +31,7 @@ BookStack is an opinionated wiki system that provides a pleasant and simple out 
 - Diagrams.net Integration
 
 
-**Поставляемая версия:** 24.12~ynh1
+**Поставляемая версия:** 24.12.1~ynh1
 
 **Демо-версия:** <https://demo.bookstackapp.com>
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -31,7 +31,7 @@ BookStack is an opinionated wiki system that provides a pleasant and simple out 
 - Diagrams.net Integration
 
 
-**分发版本：** 24.12.1~ynh2
+**分发版本：** 25.02~ynh1
 
 **演示：** <https://demo.bookstackapp.com>
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -31,7 +31,7 @@ BookStack is an opinionated wiki system that provides a pleasant and simple out 
 - Diagrams.net Integration
 
 
-**分发版本：** 24.12~ynh1
+**分发版本：** 24.12.1~ynh1
 
 **演示：** <https://demo.bookstackapp.com>
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "BookStack"
 description.en = "Platform to create documentation/wiki content"
 description.fr = "Plateforme pour créer du contenu de documentation/wiki"
 
-version = "24.12~ynh1"
+version = "24.12.1~ynh1"
 
 maintainers = ["eric_G"]
 
@@ -59,8 +59,8 @@ ram.runtime = "50M"
     [resources.sources]
 
         [resources.sources.main]
-        url = "https://github.com/BookStackApp/BookStack/archive/refs/tags/v24.12.tar.gz"
-        sha256 = "322e13ee452bb62b3e96db70c7ef035392d08e52238b92e4a3ad91a8b75e1281"
+        url = "https://github.com/BookStackApp/BookStack/archive/refs/tags/v24.12.1.tar.gz"
+        sha256 = "94303fbe47e202225c22ec45d67617cf9de0a17a576f973426435cd73cc4e64d"
         rename = "bookstack.tar.gz"
         autoupdate.strategy = "latest_github_release"
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "BookStack"
 description.en = "Platform to create documentation/wiki content"
 description.fr = "Plateforme pour créer du contenu de documentation/wiki"
 
-version = "24.12.1~ynh2"
+version = "25.02~ynh1"
 
 maintainers = ["eric_G"]
 
@@ -61,8 +61,8 @@ ram.runtime = "50M"
     [resources.sources]
 
     [resources.sources.main]
-    url = "https://github.com/BookStackApp/BookStack/archive/refs/tags/v24.12.1.tar.gz"
-    sha256 = "94303fbe47e202225c22ec45d67617cf9de0a17a576f973426435cd73cc4e64d"
+    url = "https://github.com/BookStackApp/BookStack/archive/refs/tags/v25.02.tar.gz"
+    sha256 = "b6d9ba927ca4c797484152f35ccd40ad06952f0f0437311f7f6660f879d08613"
     rename = "bookstack.tar.gz"
     autoupdate.strategy = "latest_github_release"
 


### PR DESCRIPTION
Upgrade sources
- `main` v25.02.1: https://github.com/BookStackApp/BookStack/releases/tag/v25.02.1

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
